### PR TITLE
Build fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 vendor
 contracts/build
 contracts/node_modules
+package-lock.json
+.DS_Store

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -190,6 +190,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b65593088d7a0f3deecbdf2cd1094a6d0428ef89378745fcb8df589a71c093ae"
+  inputs-digest = "a2302e4bacaf963f816d90550a215879edb43b11207ad9accdc5549b970bce0c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  version = "1.8.2"
+  version = "1.8.10"
 
 [[constraint]]
   name = "github.com/keybase/go-codec"
@@ -59,4 +59,3 @@
 
 [prune]
   go-tests = true
-  unused-packages = true

--- a/README.md
+++ b/README.md
@@ -43,9 +43,14 @@ Every hour, the root node puts the last hour's worth of transactions into a Merk
 
 1. [Golang](https://golang.org/doc/install): This is primarily a golang development environment.
 2. [dep](https://github.com/golang/dep): We use ```dep``` for our dependency management.
-3. [Truffle](http://truffleframework.com/docs/getting_started/installation): For convenience, truffle is currently used to migrate Plasma contracts to the Ethereum root chain.
-4. [Ganache](https://github.com/trufflesuite/ganache): Currently we use Ganache to test against a root chain.
-5. [Geth](https://github.com/ethereum/go-ethereum/wiki/Installing-Geth): To run a local private chain for testing with web sockets and lower mining difficulty.
+3. [Node.js](https://nodejs.org/en/) and [npm](https://www.npmjs.com/get-npm)
+4. [Truffle](http://truffleframework.com/docs/getting_started/installation): For convenience, truffle is currently used 
+to migrate Plasma contracts to the Ethereum root chain. 
+**Please make sure that the version of [solc](https://github.com/trufflesuite/truffle/blob/e8c18f36801a7fd2673e96247c13818d18a93b5b/package.json#L9) used by Truffle matches the one used by the contracts. Currently, Truffle [v4.0.5](https://github.com/trufflesuite/truffle/tree/e8c18f36801a7fd2673e96247c13818d18a93b5b) 
+is most recent to support Solidity [v0.4.18](https://github.com/ethereum/solidity/tree/9cf6e910bd2b90d0c9415d9c257f85fe0c518de8)**
+```npm install -g truffle@v4.0.5 ```
+5. [Ganache](https://github.com/trufflesuite/ganache): Currently we use Ganache to test against a root chain.
+6. [Geth](https://github.com/ethereum/go-ethereum/wiki/Installing-Geth): To run a local private chain for testing with web sockets and lower mining difficulty.
 
 ## Installation and Setup
 


### PR DESCRIPTION
* Instructions regarding Truffle version to use
* Disabled prune for dep as it was ignoring C module used by go-ethereum crypto.