### PR TITLE
Outdated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 	$(MAKE) -C ./contracts abigen
 	go install ./...
 
-start: compile
+start: build
 	@./bin/start
 
 clean:

--- a/bin/start
+++ b/bin/start
@@ -19,7 +19,7 @@ echo "Starting Ganache..."
 
 (
     cd $DIR/../contracts
-    prefix_cmd 'truffle' ${cyan} "truffle develop --log --verbose-rpc --network ${NETWORK}"
+    prefix_cmd 'ganache' ${cyan} "ganache-cli -m 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat' -p 9545 --log --verbose-rpc --network ${NETWORK}"
 ) &
 
 sleep 2


### PR DESCRIPTION
makefile still referring to a, presumably, old command compile

Also, with regards to the [Known Issues](https://plasma.kyokan.io/docs/known-issues/) and specific version of ganache-cli, it is necessary to refer explicitly to ganache-cli in ./bin/start. This is because truffle develop is tied to its own version of ganache-cli (as far as I can tell).

These two minor changes recover functionality of

```
$ make start
```

while simultaneously avoiding the "0x0" bug. However, in the future, it may make more sense to use containers. 