### PR TITLE
Refactored deposit listener

### DIFF
--- a/node/deposit.go
+++ b/node/deposit.go
@@ -26,35 +26,31 @@ func StartDepositListener(storage db.PlasmaStorage, sink *TransactionSink, plasm
 		log.Printf("Looking for deposit events at block number: %d\n", lastPolledIdx)
 
 		events, topBlockIdx, err := plasma.DepositFilter(lastPolledIdx)
-		if err != nil {
-			log.Println("caught error filtering deposits:", err)
-		}
+		if err == nil {
+			if len(events) > 0 {
+				count := uint64(0)
 
-		if len(events) > 0 {
-			count := uint64(0)
+				for _, event := range events {
+					ch <- eth.DepositEvent{
+						Sender: event.Sender,
+						Value:  event.Value,
+					}
 
-			for _, event := range events {
-				ch <- eth.DepositEvent{
-					Sender: event.Sender,
-					Value:  event.Value,
+					count++
+
+					// TODO: AcceptDepositEvents is not synchronized so sleeps are required.
+					time.Sleep(time.Second * 3)
 				}
 
-				count++
-
-				// TODO: AcceptDepositEvents is not synchronized so sleeps are required.
-				time.Sleep(time.Second * 3)
+				log.Printf("Found %d deposit events at from blocks %d to %d.\n", count, lastPolledIdx, topBlockIdx)
+			} else {
+				log.Printf("No deposit events at block %d.\n", lastPolledIdx)
 			}
-
-			log.Printf("Found %d deposit events at from blocks %d to %d.\n", count, lastPolledIdx, topBlockIdx)
-
 			if err = storage.SaveDepositEventIdx(topBlockIdx + 1); err != nil {
 				log.Printf("failed to save deposit idx: %s", err)
 			}
 		} else {
-			if err = storage.SaveDepositEventIdx(topBlockIdx + 1); err != nil {
-				log.Printf("failed to save deposit idx: %s", err)
-			}
-			log.Printf("No deposit events at block %d.\n", lastPolledIdx)
+			log.Println("caught error filtering deposits:", err)
 		}
 
 		// Every 10 seconds look for deposits


### PR DESCRIPTION
Refactored deposit listener to not save most recent block index in case of error.

The most recent block index is zero when plasma.DepositFilter fails. That was written to storage and deposits from previous blocks were being applied again.