### PR TITLE
Add branch mention to read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ is most recent to support Solidity [v0.4.18](https://github.com/ethereum/solidit
 ```
 mkdir -p $GOPATH/src/github.com/kyokan
 cd $GOPATH/src/github.com/kyokan
-git clone https://github.com/kyokan/plasma.git
+git clone https://github.com/kyokan/plasma.git -b master
 cd plasma
 dep ensure
 make


### PR DESCRIPTION
As the `develop` branch is the default branch for the repo it means that they experience the issue noted in #87 by adding this explicit branch, they wont experience it.