### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ is most recent to support Solidity [v0.4.18](https://github.com/ethereum/solidit
 
 ## Installation and Setup
 
-1. Checkout, install deps, and build:
+1. Run ganache on default port 7545
+2. Checkout, install deps, and build:
 
 ```
 mkdir -p $GOPATH/src/github.com/kyokan
@@ -64,8 +65,6 @@ cd plasma
 dep ensure
 make
 ```
-
-2. Run ganache on default port 7545
 
 3. Deploy contracts:
 


### PR DESCRIPTION
Ganache needs to be running before running `make`.

Also, the docs state port `7545`, but _contracts/truffle.js_ has `9454` which breaks the `make` step. 