### PR TITLE
Fix improperly counted transactions

### DIFF
--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -32,7 +32,7 @@
     "grpc": "1.18.0",
     "int64-buffer": "0.99.1007",
     "isomorphic-fetch": "2.2.1",
-    "kyokan-plasma-client": "0.0.12",
+    "kyokan-plasma-client": "0.0.13",
     "mocha": "^5.2.0",
     "rimraf": "2.6.3",
     "truffle": "5.0.2",

--- a/kyokan-plasma-client/package.json
+++ b/kyokan-plasma-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kyokan-plasma-client",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A JavaScript client library for Kyokan's Plasma implementation.",
   "main": "./lib/Plasma.js",
   "directories": {

--- a/kyokan-plasma-client/src/domain/TransactionBody.ts
+++ b/kyokan-plasma-client/src/domain/TransactionBody.ts
@@ -109,8 +109,6 @@ export default class TransactionBody {
 
   sigHash () {
     const rlp = this.toRLP();
-    console.log(rlp.toString('hex'));
-    console.log(keccak256(rlp).toString('hex'));
     return keccak256(rlp);
   }
 }

--- a/pkg/chain/transaction_body.go
+++ b/pkg/chain/transaction_body.go
@@ -136,28 +136,35 @@ func (b *TransactionBody) OutputAt(idx uint8) *Output {
 	return b.Output1
 }
 
-func (b *TransactionBody) lookupOutput(addr *common.Address) (*Output, uint8) {
+func (b *TransactionBody) lookupOutput(addr *common.Address) ([]*Output, []uint8) {
+	var outputs []*Output
+	var indices []uint8
 	output := b.OutputAt(0)
 
 	if output.Owner == *addr {
-		return output, 0
+		outputs = append(outputs, output)
+		indices = append(indices, 0)
 	}
 
 	output = b.OutputAt(1)
-
 	if output.Owner == *addr {
-		return output, 1
+		outputs = append(outputs, output)
+		indices = append(indices, 1)
 	}
 
-	panic(fmt.Sprint("No output found for address: ", addr.Hex()))
+	if len(outputs) == 0 {
+		panic(fmt.Sprint("No output found for address: ", addr.Hex()))
+	}
+
+	return outputs, indices
 }
 
-func (b *TransactionBody) OutputFor(addr *common.Address) *Output {
-	out, _ := b.lookupOutput(addr)
-	return out
+func (b *TransactionBody) OutputsFor(addr *common.Address) []*Output {
+	outputs, _ := b.lookupOutput(addr)
+	return outputs
 }
 
-func (b *TransactionBody) OutputIndexFor(addr *common.Address) uint8 {
+func (b *TransactionBody) OutputIndicesFor(addr *common.Address) []uint8 {
 	_, idx := b.lookupOutput(addr)
 	return idx
 }

--- a/pkg/db/level_helpers.go
+++ b/pkg/db/level_helpers.go
@@ -1,20 +1,20 @@
 package db
 
 import (
-	"math/big"
-	"strconv"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/kyokan/plasma/pkg/chain"
-	"github.com/kyokan/plasma/util"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"strings"
 	"bytes"
 	"fmt"
-	"log"
-	"sort"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/kyokan/plasma/pkg/chain"
+	"github.com/kyokan/plasma/util"
 	"github.com/syndtr/goleveldb/leveldb"
-	"path"
+	"log"
+	"math/big"
 	"os/user"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 const keyPartsSeparator = "::"
@@ -64,7 +64,12 @@ func blockMetaPrefixKey(number uint64) []byte {
 }
 
 func extractAmount(tx *chain.ConfirmedTransaction, addr common.Address) *big.Int {
-	return tx.Transaction.Body.OutputFor(&addr).Amount
+	outputs := tx.Transaction.Body.OutputsFor(&addr)
+	ret := big.NewInt(0)
+	for _, output := range outputs {
+		ret = ret.Add(ret, output.Amount)
+	}
+	return ret
 }
 
 const (

--- a/pkg/db/level_storage.go
+++ b/pkg/db/level_storage.go
@@ -434,9 +434,16 @@ func (ps *LevelStorage) SpendableTxs(addr common.Address) ([]chain.ConfirmedTran
 	utxoIter := ps.db.NewIterator(levelutil.BytesPrefix(utxoAddrIterKey(addr)), nil)
 	defer utxoIter.Release()
 
-	ret := make([]chain.ConfirmedTransaction, 0)
+	seenTxs := make(map[string]bool)
+	var ret []chain.ConfirmedTransaction
 	for utxoIter.Next() {
 		txHash, _ := utxoKeyParts(string(utxoIter.Key()))
+		hexHash := hexutil.Encode(txHash)
+		if _, seen := seenTxs[hexHash]; seen {
+			continue
+		}
+		seenTxs[hexHash] = true
+
 		spendableTx, err := ps.findTransactionByHash(txHash)
 		if err != nil {
 			return nil, err
@@ -451,9 +458,16 @@ func (ps *LevelStorage) UTXOs(addr common.Address) ([]chain.ConfirmedTransaction
 	utxoIter := ps.db.NewIterator(levelutil.BytesPrefix(utxoAddrIterKey(addr)), nil)
 	defer utxoIter.Release()
 
+	seenTxs := make(map[string]bool)
 	var ret []chain.ConfirmedTransaction
 	for utxoIter.Next() {
 		txHash, _ := utxoKeyParts(string(utxoIter.Key()))
+		hexHash := hexutil.Encode(txHash)
+		if _, seen := seenTxs[hexHash]; seen {
+			continue
+		}
+		seenTxs[hexHash] = true
+
 		tx, err := ps.findTransactionByHash(txHash)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
If both outputs were assigned to the same account, balances and UTXOs were wrong.